### PR TITLE
feat: second layout

### DIFF
--- a/api/_lib/parser.ts
+++ b/api/_lib/parser.ts
@@ -5,7 +5,7 @@ import { ParsedRequest } from "./types";
 export function parseRequest(req: IncomingMessage) {
   console.log("HTTP " + req.url);
   const { pathname, query } = parse(req.url || "/", true);
-  const { fontSize, images, widths, heights, theme, md } = query || {};
+  const { fontSize, images, widths, heights, theme, layout, md } = query || {};
 
   if (Array.isArray(fontSize)) {
     throw new Error("Expected a single fontSize");
@@ -29,7 +29,8 @@ export function parseRequest(req: IncomingMessage) {
   const parsedRequest: ParsedRequest = {
     fileType: extension === "jpeg" ? extension : "png",
     text: decodeURIComponent(text),
-    theme: theme === "light" ? "light" : "dark",
+    theme: theme === "dark" ? "dark" : "light",
+    layout: layout === "center" ? "center" : "left",
     md: md === "1" || md === "true",
     fontSize: fontSize || "96px",
     images: getArray(images),

--- a/api/_lib/template.ts
+++ b/api/_lib/template.ts
@@ -22,7 +22,7 @@ const poppinsbold = readFileSync(
   `${__dirname}/../_fonts/Poppins-Bold.woff2`
 ).toString("base64");
 
-function getCss(theme: string, fontSize: string) {
+function getCss(theme: string, layout: string, fontSize: string) {
   let background = "#F7F8FA";
   let foreground = "#2F326A";
 
@@ -32,6 +32,92 @@ function getCss(theme: string, fontSize: string) {
   }
 
   let fontFamily = "Poppins";
+
+  let layoutCss = `
+      .content {
+      width: 100%;
+      display: grid;
+      grid-auto-flow: column;
+      align-items: center;
+      justify-items: start;
+      gap: 0;
+      padding: 0 !important;
+      margin: 0;
+    }
+
+    .brand {
+      width: 100%;
+      display: grid;
+      align-items: start;
+      justify-items: end;
+      padding: 0 !important;
+      margin: 0;
+    }
+    
+    .bg-grid {
+      background-image: url("https://og-cio.vercel.app/static/grid.svg");
+      background-repeat: no-repeat;
+      border-radius: 480px 480px 0 480px;
+      position: absolute;
+      width: 1090px;
+      height: 860px;
+      left: 100px;
+      top: 140px !important;
+      z-index: -1;
+      background-size: 100% 100%;
+    }
+
+    .logo {
+      margin-right: 75px;
+    }
+  `
+
+  if (layout === "center")
+  {layoutCss = `
+    .content {
+      width: 100%;
+      display: grid;
+      grid-auto-flow: row;
+      align-items: center;
+      justify-items: center;
+      gap: 0;
+      padding: 0 !important;
+      margin: 0;
+    }
+
+    .logo {
+      margin-right: 0 !important;
+    }
+
+    .images {
+      display: grid;
+      grid-auto-flow: column;
+      align-items: center;
+      gap: 75px;
+      margin: 0;
+      padding: 0;
+    }
+
+    .brand {
+      width: 100%;
+      display: grid;
+      align-items: center;
+      justify-items: center;
+      padding: 0 !important;
+      margin: 0;
+    }
+    
+    .bg-grid {
+      background-image: url("https://og-cio.vercel.app/static/grid.svg");
+      position: absolute;
+      width: 100vw;
+      height: 100vh;
+      left: 0;
+      top: 0;
+      z-index: -1;
+      background-size: 100% 100%;
+    }
+  `}
 
   return `
     @font-face {
@@ -107,42 +193,7 @@ function getCss(theme: string, fontSize: string) {
         vertical-align: -0.1em;
     }
 
-    .logo {
-      margin-right: 75px;
-    }
-
-    .content {
-      width: 100%;
-      display: grid;
-      grid-auto-flow: column;
-      align-items: center;
-      justify-items: start;
-      gap: 0;
-      padding: 0 !important;
-      margin: 0;
-    }
-
-    .brand {
-      width: 100%;
-      display: grid;
-      align-items: start;
-      justify-items: end;
-      padding: 0 !important;
-      margin: 0;
-    }
-    
-    .bg-grid {
-      background-image: url("https://og-cio.vercel.app/static/grid.svg");
-      background-repeat: no-repeat;
-      border-radius: 480px 480px 0 480px;
-      position: absolute;
-      width: 1090px;
-      height: 860px;
-      left: 100px;
-      top: 140px !important;
-      z-index: -1;
-      background-size: 100% 100%;
-    }
+    ${layoutCss}
 
     .heading {
       font-family: ${fontFamily};
@@ -154,7 +205,7 @@ function getCss(theme: string, fontSize: string) {
 }
 
 export function getHtml(parsedReq: ParsedRequest) {
-  const { text, theme, md, fontSize, images, widths, heights } = parsedReq;
+  const { text, theme, layout, md, fontSize, images, widths, heights } = parsedReq;
 
   const logoUrl =
     theme === "light"
@@ -163,24 +214,35 @@ export function getHtml(parsedReq: ParsedRequest) {
 
   const bgGrid = theme === "light" ? `<div class="bg-grid"></div>` : "";
 
+  const displayedImages = 
+    layout === "center"
+    ? images
+                  .map(
+                    (img, i) =>
+                      getPlusSign(i) + getImage(img, widths[i], heights[i])
+                  )
+                  .join("")
+    : images
+                  .map(
+                    (img, i) =>
+                      getImage(img, widths[i], heights[i])
+                  )
+                  .slice(0, 1)
+                  .join("")
+
   return `<!DOCTYPE html>
 <html>
     <meta charset="utf-8">
     <title>Generated Image</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
-        ${getCss(theme, fontSize)}
+        ${getCss(theme, layout, fontSize)}
     </style>
     <body>
       <div class="main">
         <div class="content">
-            <div>
-                ${images
-                  .map(
-                    (img, i) =>
-                      getPlusSign(i) + getImage(img, widths[i], heights[i])
-                  )
-                  .join("")}
+            <div class="images">
+                  ${displayedImages}
             </div>
             <div class="heading">${emojify(
               md ? marked(text) : sanitizeHtml(text)

--- a/api/_lib/types.ts
+++ b/api/_lib/types.ts
@@ -1,10 +1,12 @@
 export type FileType = "png" | "jpeg";
 export type Theme = "light" | "dark";
+export type Layout = "left" | "center";
 
 export interface ParsedRequest {
   fileType: FileType;
   text: string;
   theme: Theme;
+  layout: Layout;
   md: boolean;
   fontSize: string;
   images: string[];

--- a/web/index.ts
+++ b/web/index.ts
@@ -1,4 +1,4 @@
-import { ParsedRequest, Theme, FileType } from "../api/_lib/types";
+import { ParsedRequest, Theme, Layout, FileType } from "../api/_lib/types";
 const { H, R, copee } = window as any;
 let timeout = -1;
 
@@ -132,6 +132,11 @@ const themeOptions: DropdownOption[] = [
   { text: "Dark", value: "dark" },
 ];
 
+const layoutOptions: DropdownOption[] = [
+  { text: "Left", value: "left" },
+  { text: "Center", value: "center" },
+];
+
 const fileTypeOptions: DropdownOption[] = [
   { text: "PNG", value: "png" },
   { text: "JPEG", value: "jpeg" },
@@ -238,6 +243,7 @@ const App = (_: any, state: AppState, setState: SetState) => {
     fileType = "png",
     fontSize = "100px",
     theme = "light",
+    layout = "left",
     md = true,
     text = `Where your title would go`,
     images = [imageOptions[0].value],
@@ -254,6 +260,7 @@ const App = (_: any, state: AppState, setState: SetState) => {
   const url = new URL(window.location.origin);
   url.pathname = `${encodeURIComponent(text)}.${fileType}`;
   url.searchParams.append("theme", theme);
+  url.searchParams.append("layout", layout);
   url.searchParams.append("md", mdValue);
   url.searchParams.append("fontSize", fontSize);
   for (let image of images) {
@@ -284,6 +291,19 @@ const App = (_: any, state: AppState, setState: SetState) => {
               let clone = [...images];
               clone[0] = options[selectedImageIndex].value;
               setLoadingState({ theme: val, images: clone });
+            },
+          }),
+        }),
+        H(Field, {
+          label: "Layout",
+          input: H(Dropdown, {
+            options: layoutOptions,
+            value: layout,
+            onchange: (val: Layout) => {
+              const options = imageOptions;
+              let clone = [...images];
+              clone[0] = options[selectedImageIndex].value;
+              setLoadingState({ layout: val, images: clone });
             },
           }),
         }),


### PR DESCRIPTION
Allows a second layout `center`
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/4112343/138131643-3bb3c374-802c-402a-b113-cd76dad703e6.png">


Default is `left` and only displays 1 image, even if more are specified:
<img width="1801" alt="image" src="https://user-images.githubusercontent.com/4112343/138131579-d529ac83-2d85-4147-991d-a53d583e34bd.png">


Center can be enabled and accepts multiple images:
<img width="1751" alt="image" src="https://user-images.githubusercontent.com/4112343/138131369-f4a4cadb-e816-4d34-b6ba-79b3191900a5.png">
