### PR TITLE
add new directories, remove recipes

### DIFF
--- a/web/index.ts
+++ b/web/index.ts
@@ -172,10 +172,17 @@ const imageOptions: DropdownOption[] = [
     value: "https://og-cio.vercel.app/static/customer-data.svg",
   },
   {
-    text: "Messaging",
+    text: "Liquid",
+    value: "https://og-cio.vercel.app/static/customer-data.svg",
+  },
+  {
+    text: "Campaigns and Workflows",
     value: "https://og-cio.vercel.app/static/messaging.svg",
   },
-  { text: "Recipes", value: "https://og-cio.vercel.app/static/recipes.svg" },
+  {
+    text: "Messages and Webhooks",
+    value: "https://og-cio.vercel.app/static/messaging.svg",
+  },
   {
     text: "Integrations",
     value: "https://og-cio.vercel.app/static/integrations.svg",


### PR DESCRIPTION
I pushed an update to the docs on friday that reorganized/moved some directories. I totally forgot that I needed to account for these moves in this repo.

New directories: `campaigns-and-workflows`, `messages-and-webhooks` ("message channels" in the UI), `liquid`.
Deleted directories: `messaging`, `recipes`.

If my changes are right, we can commission some new graphics from the design crew later. I just want to fix the immediate issue ASAP.